### PR TITLE
Fix [Deprecated] The background method is deprecated.

### DIFF
--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -80,7 +80,7 @@ namespace :sneakers do
 
   def quiet_sneakers(pid_file)
     if fetch(:sneakers_use_signals) || fetch(:sneakers_run_config)
-      background :kill, "-USR1 `cat #{pid_file}`"
+      execute :kill, "-USR1 `cat #{pid_file}`"
     else
       begin
         execute :bundle, :exec, :sneakersctl, 'quiet', "#{pid_file}"


### PR DESCRIPTION
This is a deprecation, which seems harmless at first:

```
[Deprecated] The background method is deprecated. Blame badly behaved pseudo-daemons!
    (Called from /home/antasa/.rvm/gems/ruby-2.3.1@expert/gems/capistrano-sneakers-0.0.1/lib/capistrano/tasks/sneakers.rb:83:in `quiet_sneakers')
```

but basically means that [this line](https://github.com/inventionlabsSydney/capistrano-sneakers/blob/master/lib/capistrano/tasks/sneakers.rb#L83) was not run and later on deploy will fall apart with:

```
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deploy@expert-dev.uol.as: kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` exit status: 2
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stdout: sh: 1: kill: Illegal option -S
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stderr: Nothing written

SSHKit::Command::Failed: kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` exit status: 2
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stdout: sh: 1: kill: Illegal option -S
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stderr: Nothing written

Tasks: TOP => sneakers:stop
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as deploy@expert-dev.uol.as: kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` exit status: 2
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stdout: sh: 1: kill: Illegal option -S
kill -SIGTERM `cat /srv/www/expert-dev/shared/tmp/pids/sneakers.pid` stderr: Nothing written
```

I had a look and is simply this change of one word since in that place there is no check for `stop_sneakers_in_background` and from my point of view does not make sense there anyway.

This is as simple as it gets and I can confirm corrects the situation and behaves correctly.

Thanks a lot 👍 