### PR TITLE
Fix start_sneakers undefined variable issue

### DIFF
--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -131,9 +131,9 @@ namespace :sneakers do
       end
 
       if fetch(:start_sneakers_in_background, fetch(:sneakers_run_in_background))
-        background :bundle, :exec, :sneakers, args.compact.join(' ')
+        background :bundle, :exec, :sneakers, :work, args.compact.join(' ')
       else
-        execute :bundle, :exec, :sneakers, args.compact.join(' ')
+        execute :bundle, :exec, :sneakers, :work, args.compact.join(' ')
       end
     end
   end

--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -131,9 +131,9 @@ namespace :sneakers do
       end
 
       if fetch(:start_sneakers_in_background, fetch(:sneakers_run_in_background))
-        background :bundle, :exec, :sneakers, :work, args.compact.join(' ')
+        background :bundle, :exec, :sneakers, args.compact.join(' ')
       else
-        execute :bundle, :exec, :sneakers, :work, args.compact.join(' ')
+        execute :bundle, :exec, :sneakers, args.compact.join(' ')
       end
     end
   end

--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -107,6 +107,7 @@ namespace :sneakers do
       end
       #execute :bundle, :exec, :sneakers, args.compact.join(' ')
     else
+      args = []
       # Using custom sneakers setup
       args.push "--index #{idx}"
       args.push "--pidfile #{pid_file}"


### PR DESCRIPTION
```
(Backtrace restricted to imported tasks)
cap aborted!
NameError: undefined local variable or method `args' for #<SSHKit::Backend::Netssh:0x007fff4796b038>

Tasks: TOP => sneakers:start
```