### PR TITLE
Make sneakers:stop task perpetually callable

### DIFF
--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -189,6 +189,7 @@ namespace :sneakers do
         end
       end
     end
+    Rake::Task["sneakers:stop"].reenable
   end
 
   desc 'Start sneakers'

--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -97,12 +97,12 @@ namespace :sneakers do
       raise "[ set :workers, ['worker1', 'workerN'] ] not configured properly, please configure the workers you wish to use" if fetch(:sneakers_workers).nil? or fetch(:sneakers_workers) == false or !fetch(:sneakers_workers).kind_of? Array
 
       workers = fetch(:sneakers_workers).compact.join(',')
-      
+
       #run "cmd", env: { 'WORKERS' => workers } #export this to environmental variable
       info "Starting the sneakers processes"
       #workers.each do |worker|
 
-      with rails_env: fetch(:sneakers_env), workers: workers do 
+      with rails_env: fetch(:sneakers_env), workers: workers do
         rake 'sneakers:run'
       end
       #execute :bundle, :exec, :sneakers, args.compact.join(' ')


### PR DESCRIPTION
Due to rake task intentional behaviour to be called only once by default, there is an issue with a restarting `sneakers` during deploy:

```
00:00 sneakers:stop
      01 kill -SIGTERM `cat /app/shared/tmp/pids/sneakers.pid`
00:00 deploy:symlink:release
      01 ln -s /app/releases/20179999999 /app/releases/current
      02 mv /app/releases/current /app
Skipping task `sneakers:stop'.
Capistrano tasks may only be invoked once. Since task `sneakers:stop' was previously invoked, invoke("sneakers:stop") at /Users/tensho/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/capistrano-sneakers-63514ab50434/lib/capistrano/tasks/sneakers.rb:207 will be skipped.
If you really meant to run this task again, first call Rake::Task["sneakers:stop"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
00:00 deploy:restart
```

I don't know when `capistrano` resolve this issue, so would like to cherry pick here similar solution from `capistrano-sidekiq`.

Crosslinks

- https://github.com/seuros/capistrano-sidekiq/pull/164
- https://github.com/capistrano/capistrano/issues/1686
- https://github.com/capistrano/capistrano/pull/1911
