### PR TITLE
Use new capistrano DSL for reenable tasks

### DIFF
--- a/lib/capistrano/tasks/sneakers.rb
+++ b/lib/capistrano/tasks/sneakers.rb
@@ -189,7 +189,6 @@ namespace :sneakers do
         end
       end
     end
-    Rake::Task["sneakers:stop"].reenable
   end
 
   desc 'Start sneakers'
@@ -205,7 +204,7 @@ namespace :sneakers do
 
   desc 'Restart sneakers'
   task :restart do
-    invoke 'sneakers:stop'
+    invoke! 'sneakers:stop'
     invoke 'sneakers:start'
   end
 


### PR DESCRIPTION
### Summary

After the long discussion of the issue (capistrano/capistrano#1686) related to re-enabling capistrano tasks, there was merged PR that introduced new `#invoke!`, that should resolve custom rake task re-enabling [here](https://github.com/inventionlabsSydney/capistrano-sneakers/blob/master/lib/capistrano/tasks/sneakers.rb#L192) and [capistrano-sidekiq](https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/sidekiq.rake#L157).

### Cross references

- seuros/capistrano-sidekiq#177