### PR TITLE
Declare gem dependencies

### DIFF
--- a/capistrano-sneakers.gemspec
+++ b/capistrano-sneakers.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
+  spec.add_dependency 'capistrano', '>= 3.9.0'
+  spec.add_dependency 'sneakers'
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
We need to declare gem dependencies to be sure that [new capistrano public API](https://github.com/inventionlabsSydney/capistrano-sneakers/pull/7) is available to specific gem version. It seems to me there is no `specific` version of sneakers required for this gem, but maybe you know better `sneakers` obligations, so I'm glad to add needed one ^_^

### Crosslinks

https://github.com/capistrano/capistrano/releases/tag/v3.9.0
https://github.com/seuros/capistrano-sidekiq/pull/177