### PR TITLE
Correct Timing in Sneakers Restart Task

### DIFF
--- a/capistrano-sneakers.gemspec
+++ b/capistrano-sneakers.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'capistrano/sneakers/version'

--- a/lib/capistrano/sneakers.rb
+++ b/lib/capistrano/sneakers.rb
@@ -1,11 +1,1 @@
-require 'capistrano/sneakers/version'
-
-cap_version = Gem::Specification.find_by_name('capistrano').version
-if cap_version >= Gem::Version.new('3.0.0')
-  #
-  # Load Tasks from sneakers "cap" file
-  #
-  load File.expand_path('../tasks/sneakers.rake', __FILE__)
-else
-  raise Gem::LoadError, "Capistrano-Sneakers requires capistrano version 3.0.0 or greater, version detected: #{cap_version}"
-end
+load File.expand_path('../tasks/sneakers.rake', __FILE__)

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -63,5 +63,24 @@ namespace :sneakers do
     def sudo_if_needed(command)
       fetch(:sneakers_monit_use_sudo) ? sudo(command) : execute(command)
     end
+
+    def template_sneakers(from, to, role)
+      [
+        File.join('lib', 'capistrano', 'templates', "#{from}-#{role.hostname}-#{fetch(:stage)}.rb"),
+        File.join('lib', 'capistrano', 'templates', "#{from}-#{role.hostname}.rb"),
+        File.join('lib', 'capistrano', 'templates', "#{from}-#{fetch(:stage)}.rb"),
+        File.join('lib', 'capistrano', 'templates', "#{from}.rb.erb"),
+        File.join('lib', 'capistrano', 'templates', "#{from}.rb"),
+        File.join('lib', 'capistrano', 'templates', "#{from}.erb"),
+        File.expand_path("../../templates/#{from}.rb.erb", __FILE__),
+        File.expand_path("../../templates/#{from}.erb", __FILE__)
+      ].each do |path|
+        if File.file?(path)
+          erb = File.read(path)
+          upload! StringIO.new(ERB.new(erb).result(binding)), to
+          break
+        end
+      end
+    end
   end
 end

--- a/lib/capistrano/tasks/sneakers.rake
+++ b/lib/capistrano/tasks/sneakers.rake
@@ -252,23 +252,4 @@ namespace :sneakers do
       end
     end
   end
-
-  def template_sneakers(from, to, role)
-    [
-        File.join('lib', 'capistrano', 'templates', "#{from}-#{role.hostname}-#{fetch(:stage)}.rb"),
-        File.join('lib', 'capistrano', 'templates', "#{from}-#{role.hostname}.rb"),
-        File.join('lib', 'capistrano', 'templates', "#{from}-#{fetch(:stage)}.rb"),
-        File.join('lib', 'capistrano', 'templates', "#{from}.rb.erb"),
-        File.join('lib', 'capistrano', 'templates', "#{from}.rb"),
-        File.join('lib', 'capistrano', 'templates', "#{from}.erb"),
-        File.expand_path("../../templates/#{from}.rb.erb", __FILE__),
-        File.expand_path("../../templates/#{from}.erb", __FILE__)
-    ].each do |path|
-      if File.file?(path)
-        erb = File.read(path)
-        upload! StringIO.new(ERB.new(erb).result(binding)), to
-        break
-      end
-    end
-  end
 end

--- a/lib/capistrano/tasks/sneakers.rake
+++ b/lib/capistrano/tasks/sneakers.rake
@@ -1,5 +1,4 @@
 namespace :load do
-
   task :defaults do
     set :sneakers_default_hooks, -> { true }
 
@@ -18,9 +17,7 @@ namespace :load do
   end
 end
 
-
 namespace :deploy do
-
   before :starting, :check_sneakers_hooks do
     invoke 'sneakers:add_default_hooks' if fetch(:sneakers_default_hooks)
   end
@@ -31,7 +28,6 @@ namespace :deploy do
 end
 
 namespace :sneakers do
-
   def for_each_sneakers_process(reverse = false, &block)
     pids = processes_sneakers_pids
     pids.reverse! if reverse
@@ -155,9 +151,9 @@ namespace :sneakers do
   end
 
   task :add_default_hooks do
-    after 'deploy:starting', 'sneakers:quiet'
-    after 'deploy:updated', 'sneakers:stop'
-    after 'deploy:reverted', 'sneakers:stop'
+    after 'deploy:starting',  'sneakers:quiet'
+    after 'deploy:updated',   'sneakers:stop'
+    after 'deploy:reverted',  'sneakers:stop'
     after 'deploy:published', 'sneakers:start'
   end
 
@@ -196,7 +192,9 @@ namespace :sneakers do
     on roles fetch(:sneakers_role) do |role|
       as_sneakers_user(role) do
         for_each_sneakers_process do |pid_file, idx|
-          start_sneakers(pid_file, idx) unless sneakers_pid_process_exists?(pid_file)
+          unless sneakers_pid_process_exists?(pid_file)
+            start_sneakers(pid_file, idx)
+          end
         end
       end
     end

--- a/lib/capistrano/tasks/sneakers.rake
+++ b/lib/capistrano/tasks/sneakers.rake
@@ -205,6 +205,9 @@ namespace :sneakers do
   desc 'Restart sneakers'
   task :restart do
     invoke! 'sneakers:stop'
+    # It takes some time to stop serverengine processes and cleanup pidfiles.
+    # We should wait until pidfiles will be removed.
+    sleep 5
     invoke 'sneakers:start'
   end
 


### PR DESCRIPTION
`sneakers:restart` task doesn't work properly, because there is not enough time interval for [serverengine](https://github.com/treasure-data/serverengine) between `stop` and `start` tasks to cleanup pidfiles. `start` task verifies that pidfiles exist and skips. I'd like to insert sleep for now. After that I'm going to develop `sneakersctl` similar to [`sidekiqctl`](https://github.com/mperham/sidekiq/blob/master/bin/sidekiqctl) that will help to control processes behavior with signals and perform all required cleanup.

### Improvement

* Current [gemspec holds dependency version `3.9.0`](https://github.com/inventionlabsSydney/capistrano-sneakers/blob/master/capistrano-sneakers.gemspec#L23).