### PR TITLE
Mimicry capistrano-sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
-- Add CHANGELOG @Tensho
+## 0.1.0
+
+- Mimicry capistrano-sidekiq @Tensho
+- Add sneakers_monit_templates_path @Tensho
 
 ## 0.0.2
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configurable options, shown here with defaults:
 # sneakers monit
 :sneakers_monit_conf_dir => '/etc/monit/conf.d'
 :sneakers_monit_use_sudo => true
-:sneakers_monit_bin => '/usr/bin/monit'
+:monit_bin => '/usr/bin/monit'
 :sneakers_monit_templates_path => 'config/deploy/templates'
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,36 +6,44 @@
 
 Add this line to your application's Gemfile:
 
-```ruby
-gem 'capistrano-sneakers'
-```
+    gem 'capistrano-sneakers', github: 'inventionlabsSydney/capistrano-sneakers'
 
 And then execute:
 
     $ bundle
 
-Or install it yourself as:
-
-    $ gem install capistrano-sneakers
-
 ## Usage
 
-## Usage
 ```ruby
 # Capfile
-
 require 'capistrano/sneakers'
-# Include monit tasks
-# require 'capistrano/sneakers/monit'
+require 'capistrano/sneakers/monit' # optional, to require monit tasks
+```
+
+Configurable options, shown here with defaults:
+
+```ruby
+:sneakers_default_hooks => true
+:sneakers_pid => File.join(shared_path, 'tmp', 'pids', 'sneakers.pid') # ensure this path exists in production before deploying
+:sneakers_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
+:sneakers_log => File.join(shared_path, 'log', 'sneakers.log')
+:sneakers_role => :app
+:sneakers_processes => 1
+# sneakers monit
+:sneakers_monit_conf_dir => '/etc/monit/conf.d'
+:sneakers_monit_use_sudo => true
+:sneakers_monit_bin => '/usr/bin/monit'
+:sneakers_monit_templates_path => 'config/deploy/templates'
 ```
 
 ## Contributors
 
+- [Andrew Babichev](https://github.com/Tensho)
 - [NaixSpirit](https://github.com/NaixSpirit)
 
 ## Contributing
 
-1. Fork it ( https://github.com/NaixSpirit/capistrano-sneakers/fork )
+1. Fork it (https://github.com/inventionlabsSydney/capistrano-sneakers)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Configurable options, shown here with defaults:
 :sneakers_pid => File.join(shared_path, 'tmp', 'pids', 'sneakers.pid') # ensure this path exists in production before deploying
 :sneakers_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sneakers_log => File.join(shared_path, 'log', 'sneakers.log')
-:sneakers_role => :app
+:sneakers_roles => :app
 :sneakers_processes => 1
 # sneakers monit
 :sneakers_monit_conf_dir => '/etc/monit/conf.d'

--- a/capistrano-sneakers.gemspec
+++ b/capistrano-sneakers.gemspec
@@ -5,11 +5,11 @@ require 'capistrano/sneakers/version'
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-sneakers"
   spec.version       = Capistrano::Sneakers::VERSION
-  spec.authors       = ["Spirit"]
-  spec.email         = ["neverlandxy.naix@gmail.com"]
-  spec.summary       = %q{Sneakers integration only for Capistrano3}
-  spec.description   = %q{Sneakers integration only for Capistrano3}
-  spec.homepage      = "https://github.com/NaixSpirit/capistrano-sneakers"
+  spec.authors       = ["Karl Kloppenborg, Andrew Babichev, NaixSpirit"]
+  spec.email         = ["karl@hyperconnect.com.au", "andrew.babichev@gmail.com", "neverlandxy.naix@gmail.com"]
+  spec.summary       = %q{Sneakers integration for Capistrano}
+  spec.description   = %q{Sneakers integration for Capistrano}
+  spec.homepage      = "https://github.com/inventionlabsSydney/capistrano-sneakers"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/lib/capistrano/sneakers/version.rb
+++ b/lib/capistrano/sneakers/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Sneakers
-    VERSION = "0.0.2"
+    VERSION = "0.1.0"
   end
 end

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -9,7 +9,7 @@ end
 
 namespace :sneakers do
   namespace :monit do
-    desc 'Add Sneakers to monit'
+    desc 'Config Sneakers monit-service'
     task :config do
       on roles(fetch(:sneakers_role)) do |role|
         @role = role
@@ -22,35 +22,35 @@ namespace :sneakers do
       end
     end
 
-    desc 'Enable Sneakers monit'
+    desc 'Monitor Sneakers monit-service'
     task :monitor do
       on roles(fetch(:sneakers_role)) do
         sudo_if_needed "#{fetch(:sneakers_monit_bin)} monitor #{sneakers_service_name}"
       end
     end
 
-    desc 'Disable Sneakers monit'
+    desc 'Unmonitor Sneakers monit-service'
     task :unmonitor do
       on roles(fetch(:sneakers_role)) do
         sudo_if_needed "#{fetch(:sneakers_monit_bin)} unmonitor #{sneakers_service_name}"
       end
     end
 
-    desc 'Start Sneakers through monit'
+    desc 'Start Sneakers monit-service'
     task :start do
       on roles(fetch(:sneakers_role)) do
         sudo_if_needed "#{fetch(:sneakers_monit_bin)} start #{sneakers_service_name}"
       end
     end
 
-    desc 'Stop Sneakers through monit'
+    desc 'Stop Sneakers monit-service'
     task :stop do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)}  stop #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:sneakers_monit_bin)} stop #{sneakers_service_name}"
       end
     end
 
-    desc 'Restart Sneakers through monit'
+    desc 'Restart Sneakers monit-service'
     task :restart do
       on roles(fetch(:sneakers_role)) do
         sudo_if_needed "#{fetch(:sneakers_monit_bin)} restart #{sneakers_service_name}"

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -1,9 +1,9 @@
 namespace :load do
   task :defaults do
+    set :monit_bin, '/usr/bin/monit'
     set :sneakers_monit_default_hooks, true
     set :sneakers_monit_conf_dir, -> { '/etc/monit/conf.d' }
     set :sneakers_monit_use_sudo, true
-    set :sneakers_monit_bin, '/usr/bin/monit'
     set :sneakers_monit_templates_path, 'config/deploy/templates'
   end
 end
@@ -32,42 +32,42 @@ namespace :sneakers do
         mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sneakers_monit_conf_dir)}/#{sneakers_service_name}.conf"
         sudo_if_needed mv_command
 
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} reload"
+        sudo_if_needed "#{fetch(:monit_bin)} reload"
       end
     end
 
     desc 'Monitor Sneakers monit-service'
     task :monitor do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} monitor #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
       end
     end
 
     desc 'Unmonitor Sneakers monit-service'
     task :unmonitor do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} unmonitor #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_service_name}"
       end
     end
 
     desc 'Start Sneakers monit-service'
     task :start do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} start #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} start #{sneakers_service_name}"
       end
     end
 
     desc 'Stop Sneakers monit-service'
     task :stop do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} stop #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} stop #{sneakers_service_name}"
       end
     end
 
     desc 'Restart Sneakers monit-service'
     task :restart do
       on roles(fetch(:sneakers_role)) do
-        sudo_if_needed "#{fetch(:sneakers_monit_bin)} restart #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} restart #{sneakers_service_name}"
       end
     end
 

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -25,7 +25,7 @@ namespace :sneakers do
 
     desc 'Config Sneakers monit-service'
     task :config do
-      on roles(fetch(:sneakers_role)) do |role|
+      on roles(fetch(:sneakers_roles)) do |role|
         @role = role
         upload_sneakers_template 'sneakers_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
 
@@ -38,35 +38,35 @@ namespace :sneakers do
 
     desc 'Monitor Sneakers monit-service'
     task :monitor do
-      on roles(fetch(:sneakers_role)) do
+      on roles(fetch(:sneakers_roles)) do
         sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
       end
     end
 
     desc 'Unmonitor Sneakers monit-service'
     task :unmonitor do
-      on roles(fetch(:sneakers_role)) do
+      on roles(fetch(:sneakers_roles)) do
         sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_service_name}"
       end
     end
 
     desc 'Start Sneakers monit-service'
     task :start do
-      on roles(fetch(:sneakers_role)) do
+      on roles(fetch(:sneakers_roles)) do
         sudo_if_needed "#{fetch(:monit_bin)} start #{sneakers_service_name}"
       end
     end
 
     desc 'Stop Sneakers monit-service'
     task :stop do
-      on roles(fetch(:sneakers_role)) do
+      on roles(fetch(:sneakers_roles)) do
         sudo_if_needed "#{fetch(:monit_bin)} stop #{sneakers_service_name}"
       end
     end
 
     desc 'Restart Sneakers monit-service'
     task :restart do
-      on roles(fetch(:sneakers_role)) do
+      on roles(fetch(:sneakers_roles)) do
         sudo_if_needed "#{fetch(:monit_bin)} restart #{sneakers_service_name}"
       end
     end

--- a/lib/capistrano/tasks/sneakers.rake
+++ b/lib/capistrano/tasks/sneakers.rake
@@ -7,7 +7,7 @@ namespace :load do
     set :sneakers_log, -> { File.join(shared_path, 'log', 'sneakers.log') }
     # set :sneakers_timeout, -> 10
     # TODO: Rename to plural
-    set :sneakers_role, [:app]
+    set :sneakers_roles, [:app]
     set :sneakers_processes, 1
     set :sneakers_workers, false # if this is false it will cause Capistrano to exit
     # rename to sneakers_config

--- a/lib/generators/capistrano/sneakers/monit/template_generator.rb
+++ b/lib/generators/capistrano/sneakers/monit/template_generator.rb
@@ -1,0 +1,24 @@
+require 'rails/generators/base'
+
+module Capistrano
+  module Sneakers
+    module Monit
+      module Generators
+        class TemplateGenerator < Rails::Generators::Base
+
+          namespace "capistrano:sneakers:monit:template"
+          desc "Create local monitrc.erb, and erb files for monitored processes for customization"
+          source_root File.expand_path('../templates', __FILE__)
+          argument :templates_path, type: :string,
+            default: "config/deploy/templates",
+            banner: "path to templates"
+
+          def copy_template
+            copy_file "sneakers_monit.conf.erb", "#{templates_path}/sidekiq_monit.erb"
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/capistrano/sneakers/monit/templates/sneakers_monit.conf.erb
+++ b/lib/generators/capistrano/sneakers/monit/templates/sneakers_monit.conf.erb
@@ -1,7 +1,7 @@
 # Monit configuration for Sneakers
-# Service name: <%= sneakers_monit_service_name %>
+# Service name: <%= sneakers_service_name %>
 #
-check process <%= sneakers_monit_service_name %>
+check process <%= sneakers_service_name %>
   with pidfile "<%= fetch(:sneakers_pid) %>"
   start program = "/usr/bin/sudo -iu <%= sneakers_user(@role) %> /bin/bash -c 'cd <%= current_path %> && RAILS_ENV=<%= fetch(:sneakers_env) %> WORKERS=<%= fetch(:sneakers_workers).join(',') %> <%= SSHKit.config.command_map[:rake] %> sneakers:run'"
   stop program = "/usr/bin/sudo -iu <%= sneakers_user(@role) %> /bin/bash -c 'kill -SIGTERM `cat <%= fetch(:sneakers_pid) %>`'"


### PR DESCRIPTION
### Major notes

- Bump version to `0.1.0`
- Add `sneakers_monit_templates_path` option
- [BREAKING CHANGE] If people used custom monit template, they should adjust it to use `sneakers_service_name` variable instead of `sneakers_monit_service_name` and replace to `config/deploy/templates`.

### Minor notes

- Adjust README
- Adjust gem spec homepage info
- Moved and renamed `template_sneakers` to `monit.rake` field
- Split monit template rendering and upload

### References

- seuros/capistrano-sidekiq#190

If you don't mind I'd proceed to unify `capistrano-sneakers` and `capistrano-sidekiq` as much as possible. Also I'm going to develop `sneakersctl` to eliminate some issues related to the "manual" signal management. But I'm afraid a little bit that `sneakers` author is no more interested in it.