### PR TITLE
Re-Config Monit Service Definition on Monitor Fail

### DIFF
--- a/capistrano-sneakers.gemspec
+++ b/capistrano-sneakers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'capistrano', '>= 3.9.0'
-  spec.add_dependency 'sneakers'
+  spec.add_dependency 'sneakers', '>= 2.6'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -2,7 +2,7 @@ namespace :load do
   task :defaults do
     set :monit_bin, '/usr/bin/monit'
     set :sneakers_monit_default_hooks, true
-    set :sneakers_monit_conf_dir, -> { '/etc/monit/conf.d' }
+    set :sneakers_monit_conf_dir, '/etc/monit/conf.d'
     set :sneakers_monit_use_sudo, true
     set :sneakers_monit_templates_path, 'config/deploy/templates'
   end
@@ -20,7 +20,7 @@ namespace :sneakers do
   namespace :monit do
     task :add_default_hooks do
       before 'deploy:updating', 'sneakers:monit:unmonitor'
-      after 'deploy:published', 'sneakers:monit:monitor'
+      after  'deploy:published', 'sneakers:monit:monitor'
     end
 
     desc 'Config Sneakers monit-service'
@@ -29,7 +29,7 @@ namespace :sneakers do
         @role = role
         upload_sneakers_template 'sneakers_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
 
-        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sneakers_monit_conf_dir)}/#{sneakers_service_name}.conf"
+        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sneakers_monit_conf_dir)}/#{sneakers_monit_service_name}.conf"
         sudo_if_needed mv_command
 
         sudo_if_needed "#{fetch(:monit_bin)} reload"
@@ -40,10 +40,10 @@ namespace :sneakers do
     task :monitor do
       on roles(fetch(:sneakers_roles)) do
         begin
-          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
+          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_monit_service_name}"
         rescue
           invoke 'sneakers:monit:config'
-          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
+          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_monit_service_name}"
         end
       end
     end
@@ -52,7 +52,7 @@ namespace :sneakers do
     task :unmonitor do
       on roles(fetch(:sneakers_roles)) do
         begin
-          sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_service_name}"
+          sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_monit_service_name}"
         rescue
           # no worries here
         end
@@ -62,26 +62,26 @@ namespace :sneakers do
     desc 'Start Sneakers monit-service'
     task :start do
       on roles(fetch(:sneakers_roles)) do
-        sudo_if_needed "#{fetch(:monit_bin)} start #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} start #{sneakers_monit_service_name}"
       end
     end
 
     desc 'Stop Sneakers monit-service'
     task :stop do
       on roles(fetch(:sneakers_roles)) do
-        sudo_if_needed "#{fetch(:monit_bin)} stop #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} stop #{sneakers_monit_service_name}"
       end
     end
 
     desc 'Restart Sneakers monit-service'
     task :restart do
       on roles(fetch(:sneakers_roles)) do
-        sudo_if_needed "#{fetch(:monit_bin)} restart #{sneakers_service_name}"
+        sudo_if_needed "#{fetch(:monit_bin)} restart #{sneakers_monit_service_name}"
       end
     end
 
-    def sneakers_service_name
-      fetch(:sneakers_service_name, "sneakers_#{fetch(:application)}_#{fetch(:sneakers_env)}")
+    def sneakers_monit_service_name
+      fetch(:sneakers_monit_service_name, "sneakers_#{fetch(:application)}_#{fetch(:sneakers_env)}")
     end
 
     def sudo_if_needed(command)

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -39,14 +39,23 @@ namespace :sneakers do
     desc 'Monitor Sneakers monit-service'
     task :monitor do
       on roles(fetch(:sneakers_roles)) do
-        sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
+        begin
+          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
+        rescue
+          invoke 'sneakers:monit:config'
+          sudo_if_needed "#{fetch(:monit_bin)} monitor #{sneakers_service_name}"
+        end
       end
     end
 
     desc 'Unmonitor Sneakers monit-service'
     task :unmonitor do
       on roles(fetch(:sneakers_roles)) do
-        sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_service_name}"
+        begin
+          sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sneakers_service_name}"
+        rescue
+          # no worries here
+        end
       end
     end
 

--- a/lib/generators/capistrano/sneakers/monit/templates/sneakers_monit.conf.erb
+++ b/lib/generators/capistrano/sneakers/monit/templates/sneakers_monit.conf.erb
@@ -1,7 +1,5 @@
-# Monit configuration for Sneakers
-# Service name: <%= sneakers_service_name %>
-#
-check process <%= sneakers_service_name %>
+# Monit configuration for Sneakers : <%= fetch(:application) %>
+check process <%= sneakers_monit_service_name %>
   with pidfile "<%= fetch(:sneakers_pid) %>"
   start program = "/usr/bin/sudo -iu <%= sneakers_user(@role) %> /bin/bash -c 'cd <%= current_path %> && RAILS_ENV=<%= fetch(:sneakers_env) %> WORKERS=<%= fetch(:sneakers_workers).join(',') %> <%= SSHKit.config.command_map[:rake] %> sneakers:run'"
   stop program = "/usr/bin/sudo -iu <%= sneakers_user(@role) %> /bin/bash -c 'kill -SIGTERM `cat <%= fetch(:sneakers_pid) %>`'"


### PR DESCRIPTION
[`sidekiq:monit:monitor` task](https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/monit.rake#L48) rescues monitor action fail and tries re-upload monit service config file. I guess we should have this behavior either.

But there is a more important problem I experience in the current project – monit service template interpolates workers from `sneakers_workers` cap variable to `WORKERS` constant during configuration action [here](https://github.com/inventionlabsSydney/capistrano-sneakers/blob/master/lib/generators/capistrano/sneakers/monit/templates/sneakers_monit.conf.erb#L6). That means if I change the set of workers it will not be reflected in monit config file and will not be deployed.

### Example
```
# config/deploy.rb
set :sneakers_workers, [ 'UnoWorker' ]

# /etc/monit/conf.d/sneakers_my_app_staging.conf
# Monit configuration for Sneakers : sneakers_my_app_staging
check process sneakers_my_app_staging
  with pidfile "/mnt/data/www/my_app/shared/tmp/pids/sneakers.pid"
  start program = "/usr/bin/sudo -iu deploy /bin/bash -c 'cd /mnt/data/www/my_app/current && RAILS_ENV=staging WORKERS=Helper::CompanyReceivedWorker,Helper::MessageReceivedWorker,ResolverMailerService::EmailEventWorker,DataSyncWorker bundle exec rake sneakers:run'"
  stop program = "/usr/bin/sudo -iu deploy /bin/bash -c 'kill -SIGTERM `cat /mnt/data/www/complaint_app/shared/tmp/pids/sneakers.pid`'"
  if does not exist then restart else if succeeded then exec "/etc/monit/slack.rb"
```

I'd think about unconditional monit config update on every deploy to eliminate the described problem. But maybe I'm overseeing more trivial solution.

Also consider the next:
- Run  **all** workers without specifying `WORKERS` constant for monit mode and `set :sneakers_workers` for the regular mode **by default**
- Don't rely on `RAILS_ENV`, sneakers should have it's own environment, like `SNEAKERS_ENV`. Not all apps are based on Rails and use Sneakers (this should be changed in `sneakers` repo and I've already had a brief talk with @jondot regarding this)

@inventionlabsSydney What are your thoughts regarding this?